### PR TITLE
Update alternate xml link tag to be W3 compliant

### DIFF
--- a/code/VersionFeed_Controller.php
+++ b/code/VersionFeed_Controller.php
@@ -163,7 +163,7 @@ class VersionFeed_Controller extends Extension {
 		$url = $this->owner->getSiteRSSLink();
 
 		Requirements::insertHeadTags(
-			'<link rel="alternate nofollow" type="application/rss+xml" title="' . $title .
+			'<link rel="alternate" type="application/rss+xml" title="' . $title .
 			'" href="' . $url . '" />');
 	}
 


### PR DESCRIPTION
The link tag being produced was not W3 compliant as it was using the nofollow value in the rel attribute on a link tag which is not permitted as per the W3 standards http://www.w3.org/TR/html5/links.html#linkTypes