### PR TITLE
DEP Set PHP 7.4 as the minimum version

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -16,7 +16,7 @@
         }
     ],
     "require": {
-        "php": "^7.3 || ^8.0",
+        "php": "^7.4 || ^8.0",
         "silverstripe/cms": "^4",
         "silverstripe/versioned": "^1",
         "silverstripe/siteconfig": "^4"


### PR DESCRIPTION
Issue https://github.com/silverstripe/silverstripe-framework/issues/10219
