### PR TITLE
MNT Revert erroneous dependency changes

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -17,9 +17,9 @@
     ],
     "require": {
         "php": "^7.4 || ^8.0",
-        "silverstripe/cms": "4.13.x-dev",
-        "silverstripe/versioned": "1.13.x-dev",
-        "silverstripe/siteconfig": "4.13.x-dev"
+        "silverstripe/cms": "^4",
+        "silverstripe/versioned": "^1",
+        "silverstripe/siteconfig": "^4"
     },
     "require-dev": {
         "phpunit/phpunit": "^9.5",


### PR DESCRIPTION
Bad logic in cow resulted in many non-recipes having their constraints updated automatically when the beta was released.

## Issue
- https://github.com/silverstripe/.github/issues/33