### PR TITLE
Make sureHtmlDiff::compareHTML is not passed null values

### DIFF
--- a/src/VersionFeed.php
+++ b/src/VersionFeed.php
@@ -94,7 +94,7 @@ class VersionFeed extends SiteTreeExtension
             if (isset($previous)) {
                 // Produce the diff fields for use in the template.
                 if ($version->Title != $previous->Title) {
-                    $diffTitle = HtmlDiff::compareHTML($version->Title, $previous->Title);
+                    $diffTitle = HtmlDiff::compareHTML($version->Title ?? '', $previous->Title ?? '');
 
                     $version->DiffTitle = DBField::create_field('HTMLText', null);
                     $version->DiffTitle->setValue(
@@ -107,7 +107,7 @@ class VersionFeed extends SiteTreeExtension
                 }
 
                 if ($version->Content != $previous->Content) {
-                    $diffContent = HtmlDiff::compareHTML($version->Content, $previous->Content);
+                    $diffContent = HtmlDiff::compareHTML($version->Content ?? '', $previous->Content ?? '');
 
                     $version->DiffContent = DBField::create_field('HTMLText', null);
                     $version->DiffContent->setValue('<div>'.$diffContent.'</div>');


### PR DESCRIPTION
<!--
  Thanks for contributing, you're awesome! ⭐

  Please read https://docs.silverstripe.org/en/contributing/code/ if you haven't contributed to this project recently.
-->
## Description
When a record is saved without a title or content, when viewing the RSS changes feed, a type error occurs.

Uncaught TypeError: SilverStripe\View\Parsers\HtmlDiff::compareHtml(): Argument https://github.com/silverstripe/silverstripe-versionfeed/issues/1 ($from) must be of type array|string, null given, called in /var/www/html/vendor/silverstripe/versionfeed/src/VersionFeed.php on line 110

## Manual testing steps
I first encountered the issue with Elemental, after saving an element without a title.
But it should be the case for any page too (although it is less likely to save a page without title through the CMS).
Easiest way to reproduce is to temper with database if possible, set a page record version title or content to NULL, then visit the page URL/changes.

## Issues
<!--
  List all issues here that this pull request fixes/resolves.
  If there is no issue already, create a new one! You must link your pull request to at least one issue.
-->
- https://github.com/silverstripe/silverstripe-versionfeed/issues/95

## Pull request checklist
<!--
  PLEASE check each of these to ensure you have done everything you need to do!
  If there's something in this list you need help with, please ask so that we can assist you.
-->
- [x] The target branch is correct
    - See [picking the right version](https://docs.silverstripe.org/en/contributing/code/#picking-the-right-version)
- [x] All commits are relevant to the purpose of the PR (e.g. no debug statements, unrelated refactoring, or arbitrary linting)
    - Small amounts of additional linting are usually okay, but if it makes it hard to concentrate on the relevant changes, ask for the unrelated changes to be reverted, and submitted as a separate PR.
- [x] The commit messages follow our [commit message guidelines](https://docs.silverstripe.org/en/contributing/code/#commit-messages)
- [x] The PR follows our [contribution guidelines](https://docs.silverstripe.org/en/contributing/code/)
- [x] Code changes follow our [coding conventions](https://docs.silverstripe.org/en/contributing/coding_conventions/)
- [x] This change is covered with tests (or tests aren't necessary for this change)
- [x] Any relevant User Help/Developer documentation is updated; for impactful changes, information is added to the changelog for the intended release
- [x] CI is green


