### PR TITLE
FIX Ensure page has extension before calling method

### DIFF
--- a/src/VersionFeedController.php
+++ b/src/VersionFeedController.php
@@ -191,6 +191,7 @@ class VersionFeedController extends Extension
     {
         if (!Config::inst()->get(VersionFeed::class, 'allchanges_enabled')
             || !SiteConfig::current_site_config()->AllChangesEnabled
+            || !method_exists($this->owner, 'getSiteRSSLink')
         ) {
             return;
         }


### PR DESCRIPTION
Issue https://github.com/silverstripe/.github/issues/199

Fixes https://github.com/silverstripe/recipe-kitchen-sink/actions/runs/8058976456/job/22012645584?pr=55#step:12:73 on https://github.com/silverstripe/recipe-kitchen-sink/pull/55

`1) DNADesign\ElementalUserForms\Tests\ElementFormControllerTest::testElementFormRendering
BadMethodCallException: Object->__call(): the method 'getSiteRSSLink' does not exist on 'SilverStripe\UserForms\Control\UserDefinedFormController'`

Happened because we removed the cwp versionfeed config which disabled versionfeed. 

The elemental userforms tests has the controller extension appied by not the page extension appied, so have just added a little defensive programming here to resolve.  It's required for a cms 6 build though may as well fix for 4.13