### PR TITLE
FIX Don't use deprecated usage of get_class()

### DIFF
--- a/src/Filters/CachedContentFilter.php
+++ b/src/Filters/CachedContentFilter.php
@@ -9,7 +9,7 @@ use SilverStripe\Core\Config\Config;
  */
 class CachedContentFilter extends ContentFilter
 {
-    
+
     /**
      * Enable caching
      *
@@ -17,20 +17,20 @@ class CachedContentFilter extends ContentFilter
      * @var boolean
      */
     private static $cache_enabled = true;
-    
+
     public function getContent($key, $callback)
     {
         $cache = $this->getCache();
-        
+
         // Return cached value if available
-        $cacheEnabled = Config::inst()->get(get_class(), 'cache_enabled');
+        $cacheEnabled = Config::inst()->get(self::class, 'cache_enabled');
         $result = (isset($_GET['flush']) || !$cacheEnabled)
             ? null
             : $cache->get($key);
         if ($result) {
             return $result;
         }
-        
+
         // Fallback to generate result
         $result = parent::getContent($key, $callback);
         $lifetime = Config::inst()->get(ContentFilter::class, 'cache_lifetime') ?: null;

--- a/src/VersionFeed.php
+++ b/src/VersionFeed.php
@@ -206,7 +206,7 @@ class VersionFeed extends SiteTreeExtension
 
     public function getSiteRSSLink()
     {
-        if (Config::inst()->get(get_class(), 'allchanges_enabled')
+        if (Config::inst()->get(self::class, 'allchanges_enabled')
             && SiteConfig::current_site_config()->AllChangesEnabled
         ) {
             return $this->owner->Link('allchanges');
@@ -215,7 +215,7 @@ class VersionFeed extends SiteTreeExtension
 
     public function getDefaultRSSLink()
     {
-        if (Config::inst()->get(get_class(), 'changes_enabled') && $this->owner->PublicHistory) {
+        if (Config::inst()->get(self::class, 'changes_enabled') && $this->owner->PublicHistory) {
             return $this->owner->Link('changes');
         }
     }


### PR DESCRIPTION
## Issue
- https://github.com/silverstripe/silverstripe-versionfeed/issues/102