### PR TITLE
FIX Update CMS fields now that they're being scaffolded

### DIFF
--- a/src/VersionFeed.php
+++ b/src/VersionFeed.php
@@ -28,6 +28,12 @@ class VersionFeed extends SiteTreeExtension
         'PublicHistory' => true
     );
 
+    private static array $scaffold_cms_fields_settings = [
+        'ignoreFields' => [
+            'PublicHistory',
+        ],
+    ];
+
     protected function updateFieldLabels(&$labels)
     {
         $labels['PublicHistory'] = _t(__CLASS__ . '.LABEL', 'Make history public');


### PR DESCRIPTION
Relies on changes to `SiteTree` in https://github.com/silverstripe/silverstripe-cms/pull/2983


## Issue
- https://github.com/silverstripe/silverstripe-cms/issues/2767